### PR TITLE
add at

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/details/tuple/test_resolve_rvalue_references.cpp
                                tests/details/tuple/test_separate_tuple_elements.cpp
                                tests/details/tuple/test_try_flatten_tuple.cpp
+                               tests/details/tuple/test_tuple_indices_of.cpp
                                tests/details/tuple/test_tuple_traits.cpp
                                tests/test_and_then.cpp
                                tests/test_bind_front.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ enable_testing()
 add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/details/tuple/test_index_sequence.cpp
                                tests/details/tuple/test_separate_tuple_elements.cpp
+                               tests/details/tuple/test_try_flatten_tuple.cpp
                                tests/details/tuple/test_tuple_traits.cpp
                                tests/test_and_then.cpp
                                tests/test_bind_front.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set_target_properties(gtest gtest_main PROPERTIES
 enable_testing()
 add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/details/tuple/test_index_sequence.cpp
+                               tests/details/tuple/test_separate_tuple_elements.cpp
                                tests/test_and_then.cpp
                                tests/test_bind_front.cpp
                                tests/test_make_arg_optional.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/details/tuple/test_tuple_traits.cpp
                                tests/test_and_then.cpp
                                tests/test_bind_front.cpp
+                               tests/test_at.cpp
                                tests/test_make_arg_optional.cpp
                                tests/test_make_auto_pipe.cpp
                                tests/test_make_funky_void_removing.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set_target_properties(gtest gtest_main PROPERTIES
 # Setup for testing
 enable_testing()
 add_executable(test_funkypipes examples/readme_examples.cpp
+                               tests/details/tuple/test_index_sequence.cpp
                                tests/test_and_then.cpp
                                tests/test_bind_front.cpp
                                tests/test_make_arg_optional.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set_target_properties(gtest gtest_main PROPERTIES
 enable_testing()
 add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/details/tuple/test_index_sequence.cpp
+                               tests/details/tuple/test_resolve_rvalue_references.cpp
                                tests/details/tuple/test_separate_tuple_elements.cpp
                                tests/details/tuple/test_try_flatten_tuple.cpp
                                tests/details/tuple/test_tuple_traits.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ enable_testing()
 add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/details/tuple/test_index_sequence.cpp
                                tests/details/tuple/test_separate_tuple_elements.cpp
+                               tests/details/tuple/test_tuple_traits.cpp
                                tests/test_and_then.cpp
                                tests/test_bind_front.cpp
                                tests/test_make_arg_optional.cpp
@@ -39,6 +40,7 @@ add_executable(test_funkypipes examples/readme_examples.cpp
                                tests/test_make_signature_checking.cpp
                                tests/test_make_skippable.cpp
                                tests/test_make_tuple_packing.cpp
+                               tests/test_make_tuple_returning.cpp
                                tests/test_make_tuple_unpacking.cpp
                                tests/test_traits.cpp)
 target_link_libraries(test_funkypipes PRIVATE gtest_main)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,30 +206,6 @@ The following higher-order functions are planned to be implemented in order to e
       tap(logValue, 5);  // returns 5 and prints: "Value: 5"
       ```
 
-1. **transformAt** (index)
-    - **Type Signature**: `(a -> b) -> Int -> (a, c, d) -> (b, c, d)`
-    - **Description**: Applies a function to the nth element in a tuple.
-    - **Usage Example**:
-      ```cpp
-      std::tuple<int, double, std::string> mixedTuple = std::make_tuple(1, 2.5, "3");
-
-      auto transformFunction = [](int x) { return x * 10; };
-
-      transformAt(mixedTuple, 0, transformFunction);  // returns std::tuple<int, double, std::string>{10, 2.5, "3"}
-      ```
-
-1. **transformAt** (type)
-    - **Type Signature**: `(a -> b) -> (c, a, d) -> (c, b, d)`
-    - **Description**: Selects elements of a specific type, applies a transformation, and then merges back into the original tuple structure.
-    - **Usage Example**:
-      ```cpp
-      std::tuple<int, double, std::string> mixedTuple = std::make_tuple(1, 2.5, "3");
-
-      auto transformFunction = [](int x) { return x * 10; };
-
-      transformAt<int>(mixedTuple, transformFunction);  // returns std::tuple<int, double, std::string>{10, 2.5, "3"}
-      ```
-
 1. **transformByType**
     - **Type Signature**: `[(a -> b), (c -> d), ...] -> (a, c, ...) -> (b, d, ...)`
     - **Description**: Applies different functions to elements based on their type, and returns a tuple of the results.

--- a/include/funkypipes/at.hpp
+++ b/include/funkypipes/at.hpp
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_AT_HPP
+#define FUNKYPIPES_AT_HPP
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "funkypipes/details/make_signature_checking.hpp"
+#include "funkypipes/details/make_tuple_returning.hpp"
+#include "funkypipes/details/tuple/index_sequence.hpp"
+#include "funkypipes/details/tuple/resolve_rvalue_references.hpp"
+#include "funkypipes/details/tuple/separate_tuple_elements.hpp"
+#include "funkypipes/details/tuple/try_flatten_tuple.hpp"
+#include "funkypipes/details/tuple/tuple_indices_of.hpp"
+
+namespace funkypipes {
+
+namespace impl {
+
+// Helper trait that ectends TupleIndicesOf by asserting that the requested element was found at least once.
+template <typename TRequested, typename TTuple>
+struct TupleIndicesOfAssertingSuccessImpl {
+  using type = ::funkypipes::details::TupleIndicesOf<TRequested, TTuple>;
+  static_assert(type::size() >= 1, "At least one of the selected types is not available");
+};
+template <typename TRequested, typename TTuple>
+using TupleIndicesOfAssertingSuccess = typename TupleIndicesOfAssertingSuccessImpl<TRequested, TTuple>::type;
+
+// Helper function that forwards the arguments of the selected indices to the given function. Its result is the
+// concatenation of the remaining arguments and the function's result.
+template <typename TFn, typename TTuple, size_t... SelectedIdxs>
+auto atImpl(TFn& tupleReturningFn, TTuple argsTuple, std::index_sequence<SelectedIdxs...>) -> decltype(auto) {
+  using ::funkypipes::details::resolveRValueReferences;
+  using ::funkypipes::details::separateTupleElements;
+  using ::funkypipes::details::tryFlattenTuple;
+
+  auto [selectedArgsTuple, otherArgsTuple] = separateTupleElements<SelectedIdxs...>(std::move(argsTuple));
+
+  auto fnResultTuple = std::apply(tupleReturningFn, std::move(selectedArgsTuple));
+
+  auto otherArgsTupleWithoutRValueRefs = resolveRValueReferences(std::move(otherArgsTuple));
+
+  auto overallResultTuple = std::tuple_cat(std::move(otherArgsTupleWithoutRValueRefs), std::move(fnResultTuple));
+
+  return tryFlattenTuple(std::move(overallResultTuple));
+}
+
+}  // namespace impl
+
+// Function decorator that forwards the arguments of the selected indices to the given function. Its result is the
+// concatenation of the remaining arguments and the function's result.
+template <std::size_t... SelectedIdxs, typename TFn>
+auto at(TFn&& fn) {
+  using ::funkypipes::details::makeSignatureChecking;
+  using ::funkypipes::details::makeTupleReturning;
+  using ::funkypipes::impl::atImpl;
+
+  return [tupleReturningFn_ = makeTupleReturning(makeSignatureChecking(std::forward<TFn>(fn)))](
+             auto&&... args) mutable -> decltype(auto) {
+    auto argsTuple{std::forward_as_tuple(std::forward<decltype(args)>(args)...)};
+    return atImpl(tupleReturningFn_, std::move(argsTuple), std::index_sequence<SelectedIdxs...>{});
+  };
+}
+
+// Function decorator that forwards the arguments of the selected types to the given function. Its result is the
+// concatenation of the remaining arguments and the function's result.
+template <typename TFirstSelected, typename... TOtherSelected, typename TFn>
+auto at(TFn&& fn) {
+  using ::funkypipes::details::indexSequenceCat;
+  using ::funkypipes::details::makeSignatureChecking;
+  using ::funkypipes::details::makeTupleReturning;
+  using ::funkypipes::impl::atImpl;
+  using ::funkypipes::impl::TupleIndicesOfAssertingSuccess;
+
+  return [tupleReturningFn_ = makeTupleReturning(makeSignatureChecking(std::forward<TFn>(fn)))](
+             auto&&... args) mutable -> decltype(auto) {
+    auto argsTuple{std::forward_as_tuple(std::forward<decltype(args)>(args)...)};
+    using ArgsTuple = decltype(argsTuple);
+
+    auto selectedIndices = indexSequenceCat(TupleIndicesOfAssertingSuccess<TFirstSelected, ArgsTuple>{},
+                                            TupleIndicesOfAssertingSuccess<TOtherSelected, ArgsTuple>{}...);
+
+    return atImpl(tupleReturningFn_, std::move(argsTuple), std::move(selectedIndices));
+  };
+}
+
+}  // namespace funkypipes
+
+#endif  // FUNKYPIPES_AT_HPP

--- a/include/funkypipes/details/make_tuple_packing.hpp
+++ b/include/funkypipes/details/make_tuple_packing.hpp
@@ -25,8 +25,8 @@ auto makeTuplePacking(TFn&& fn) {
       // Note: single arguments are forwarded directly
       return fn_(std::forward<decltype(args)>(args)...);
     } else {
-      // Note: zero or multiple arguments are forwarded via tuple
-      return fn_(std::make_tuple(std::forward<decltype(args)>(args)...));
+      // Note: zero or multiple arguments are forwarded via tuple, while preserving references
+      return fn_(std::forward_as_tuple(std::forward<decltype(args)>(args)...));
     }
   };
 }

--- a/include/funkypipes/details/make_tuple_returning.hpp
+++ b/include/funkypipes/details/make_tuple_returning.hpp
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_MAKE_TUPLE_RETURNING_HPP
+#define FUNKYPIPES_DETAILS_MAKE_TUPLE_RETURNING_HPP
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/tuple/tuple_traits.hpp"
+
+namespace funkypipes::details {
+
+// Helper template function that decorates a given function by wrapping its return type with std::tuple.
+template <typename TFn>
+auto makeTupleReturning(TFn&& fn) {
+  using funkypipes::details::IsTuple;
+
+  return [fn_ = std::forward<TFn>(fn)](auto&&... args) mutable -> decltype(auto) {
+    using ResultType = typename std::invoke_result<TFn, decltype(args)...>::type;
+    if constexpr (std::is_void_v<ResultType>) {
+      fn_(std::forward<decltype(args)>(args)...);
+      return std::tuple<>{};
+    } else if constexpr (IsTuple<ResultType>) {
+      return fn_(std::forward<decltype(args)>(args)...);
+    } else {
+      // Note: References are preserved
+      if constexpr (std::is_reference_v<ResultType>) {
+        return std::forward_as_tuple(fn_(std::forward<decltype(args)>(args)...));
+      } else {
+        return std::make_tuple(fn_(std::forward<decltype(args)>(args)...));
+      }
+    }
+  };
+}
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_MAKE_TUPLE_RETURNING_HPP

--- a/include/funkypipes/details/tuple/index_sequence.hpp
+++ b/include/funkypipes/details/tuple/index_sequence.hpp
@@ -31,6 +31,41 @@ constexpr auto indexSequenceCat(TIndexSequences...) {
   return (TIndexSequences{} + ...);
 }
 
+//
+// ComplementIndexSequence
+//
+
+namespace impl {
+
+// Helper template that generates the complementary index sequence for the given size and indices
+template <std::size_t SequenceSize, std::size_t... IdxsToBeComplemented>
+struct ComplementIndexSequenceImpl {
+  template <std::size_t Idx>
+  static constexpr bool is_complement = ((Idx != IdxsToBeComplemented) && ...);
+
+  template <std::size_t Idx>
+  using index_if_complement = std::conditional_t<is_complement<Idx>, std::index_sequence<Idx>, std::index_sequence<> >;
+
+  template <std::size_t... Idxs>
+  static constexpr auto makeComplementIndexSequence(std::index_sequence<Idxs...>) {
+    static_assert(SequenceSize >= sizeof...(IdxsToBeComplemented),
+                  "The sequence size cannot be smaller than the number of indices to be complemented.");
+    if constexpr (SequenceSize == 0) {
+      return std::index_sequence<>{};
+    } else {
+      return indexSequenceCat(index_if_complement<Idxs>{}...);
+    }
+  }
+
+  using type = decltype(makeComplementIndexSequence(std::make_index_sequence<SequenceSize>{}));
+};
+}  // namespace impl
+
+// A template that generates a complementary index sequence for the given size and indices
+template <std::size_t OverallIndexCount, std::size_t... IdxsToBeComplemented>
+using ComplementIndexSequence =
+    typename impl::ComplementIndexSequenceImpl<OverallIndexCount, IdxsToBeComplemented...>::type;
+
 }  // namespace funkypipes::details
 
 #endif  // FUNKYPIPES_DETAILS_TUPLE_INDEX_SEQUENCE_HPP

--- a/include/funkypipes/details/tuple/index_sequence.hpp
+++ b/include/funkypipes/details/tuple/index_sequence.hpp
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_TUPLE_INDEX_SEQUENCE_HPP
+#define FUNKYPIPES_DETAILS_TUPLE_INDEX_SEQUENCE_HPP
+
+#include <utility>
+
+namespace funkypipes::details {
+//
+// indexSequenceCat
+//
+
+// Operator concatenating two index sequences
+namespace impl {
+template <std::size_t... LhsIdxs, std::size_t... RhsIdxs>
+constexpr auto operator+(std::index_sequence<LhsIdxs...>, std::index_sequence<RhsIdxs...>) {
+  return std::index_sequence<LhsIdxs..., RhsIdxs...>{};
+}
+}  // namespace impl
+
+// A function that concatenates any number of index_sequence objects
+template <typename... TIndexSequences>
+constexpr auto indexSequenceCat(TIndexSequences...) {
+  using ::funkypipes::details::impl::operator+;
+  return (TIndexSequences{} + ...);
+}
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_TUPLE_INDEX_SEQUENCE_HPP

--- a/include/funkypipes/details/tuple/resolve_rvalue_references.hpp
+++ b/include/funkypipes/details/tuple/resolve_rvalue_references.hpp
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_TUPLE_RESOLVE_RVALUE_REFERENCES_HPP
+#define FUNKYPIPES_DETAILS_TUPLE_RESOLVE_RVALUE_REFERENCES_HPP
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace funkypipes::details {
+
+namespace impl {
+
+// Helper type trait that removes rvalue references
+template <typename T>
+using RemoveRValueReference = std::conditional_t<std::is_rvalue_reference_v<T>, std::remove_reference_t<T>, T>;
+
+// This helper function replaces rvalue references with their corresponding value types, transforming the types of the
+// tuple elements.
+template <typename TTuple, std::size_t... Idxs>
+auto resolveRValueReferencesImpl(TTuple&& tuple, std::index_sequence<Idxs...>) {
+  using ResultTuple = std::tuple<RemoveRValueReference<std::tuple_element_t<Idxs, std::decay_t<TTuple>>>...>;
+  return ResultTuple{std::get<Idxs>(std::forward<TTuple>(tuple))...};
+}
+
+}  // namespace impl
+
+// Function transforming a given tuple by replacing rvalue reference elements with value elements.
+template <typename... TElements>
+auto resolveRValueReferences(std::tuple<TElements...>& tuple) {
+  return ::funkypipes::details::impl::resolveRValueReferencesImpl(tuple, std::index_sequence_for<TElements...>());
+}
+
+// Function transforming a given tuple by replacing rvalue reference elements with value elements.
+template <typename... TElements>
+auto resolveRValueReferences(const std::tuple<TElements...>& tuple) {
+  return ::funkypipes::details::impl::resolveRValueReferencesImpl(tuple, std::index_sequence_for<TElements...>());
+}
+
+// Function transforming a given tuple by replacing rvalue reference elements with value elements.
+template <typename... TElements>
+auto resolveRValueReferences(std::tuple<TElements...>&& tuple) {
+  return ::funkypipes::details::impl::resolveRValueReferencesImpl(std::move(tuple),
+                                                                  std::index_sequence_for<TElements...>());
+}
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_TUPLE_RESOLVE_RVALUE_REFERENCES_HPP

--- a/include/funkypipes/details/tuple/separate_tuple_elements.hpp
+++ b/include/funkypipes/details/tuple/separate_tuple_elements.hpp
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_TUPLE_SEPARATE_TUPLE_ELEMENTS_HPP
+#define FUNKYPIPES_DETAILS_TUPLE_SEPARATE_TUPLE_ELEMENTS_HPP
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/tuple/index_sequence.hpp"
+
+namespace funkypipes::details {
+
+namespace impl {
+
+// Helper function that creates a new tuple based on the given one, using the specified indices. Only the
+// elements at Idxs are accessed, all other elements are not touched. The original element types are preserved.
+template <typename TTuple, std::size_t... Idxs>
+auto recreateTupleFromIndices(TTuple&& tuple, std::index_sequence<Idxs...>) {
+  using ResultTuple = std::tuple<std::tuple_element_t<Idxs, std::decay_t<TTuple>>...>;
+  return ResultTuple{std::get<Idxs>(std::forward<TTuple>(tuple))...};
+}
+
+// Implementation of separating the specified elements of a given tuple into two tuples, one that contains the separated
+// elements and another containing the remaining ones.
+template <std::size_t... IdxsToSeparate, typename TTuple>
+auto separateTupleElements(TTuple&& tuple) {
+  constexpr std::size_t tupleSize = std::tuple_size<std::decay_t<TTuple>>::value;
+  static_assert(((IdxsToSeparate < tupleSize) && ...), "Index out of range");
+
+  // Note: Forwarding the tuple twice is intended and not an issue, as recreateTupleFromIndices does only modify the
+  // specified tuple elements which are distinct for both calls
+
+  auto separatedIndices = std::index_sequence<IdxsToSeparate...>{};
+  auto separatedElements = recreateTupleFromIndices(std::forward<TTuple>(tuple), std::move(separatedIndices));
+
+  auto remainingIndices = ComplementIndexSequence<tupleSize, IdxsToSeparate...>{};
+  auto remainingElements = recreateTupleFromIndices(std::forward<TTuple>(tuple), std::move(remainingIndices));
+
+  return std::make_pair(std::move(separatedElements), std::move(remainingElements));
+}
+
+}  // namespace impl
+
+// This function takes an lvalue tuple as input and returns the separated element, along with a new tuple containing the
+// remaining elements.
+template <std::size_t... IdxsToSeparate, typename... TElements>
+auto separateTupleElements(std::tuple<TElements...>& tuple) {
+  return impl::separateTupleElements<IdxsToSeparate...>(tuple);
+}
+
+// This function takes an const lvalue tuple as input and returns the separated element, along with a new tuple
+// containing the remaining elements.
+template <std::size_t... IdxsToSeparate, typename... TElements>
+auto separateTupleElements(const std::tuple<TElements...>& tuple) {
+  return impl::separateTupleElements<IdxsToSeparate...>(tuple);
+}
+
+// This function takes an rvalue tuple as input and returns the separated element, along with a new tuple containing the
+// remaining elements.
+template <std::size_t... IdxsToSeparate, typename... TElements>
+auto separateTupleElements(std::tuple<TElements...>&& tuple) {
+  return impl::separateTupleElements<IdxsToSeparate...>(std::move(tuple));
+}
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_TUPLE_SEPARATE_TUPLE_ELEMENTS_HPP

--- a/include/funkypipes/details/tuple/try_flatten_tuple.hpp
+++ b/include/funkypipes/details/tuple/try_flatten_tuple.hpp
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_TUPLE_TRY_FLATTEN_TUPLE_HPP
+#define FUNKYPIPES_DETAILS_TUPLE_TRY_FLATTEN_TUPLE_HPP
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace funkypipes::details {
+
+// This function returns void for empty tuples, the only element for single-element tuples, and the tuple itself
+// otherwise. It preserves references when returning a single element, and tuples are returned by value.
+template <typename TTuple>
+constexpr decltype(auto) tryFlattenTuple(TTuple&& tuple) {
+  constexpr auto size = std::tuple_size_v<std::decay_t<TTuple>>;
+  if constexpr (size == 0) {
+    return;
+  } else if constexpr (size == 1) {
+    // Note: Preserve element references
+    using ElementType = std::tuple_element_t<0, std::decay_t<TTuple>>;
+    if constexpr (std::is_reference_v<ElementType>) {
+      return std::get<0>(std::forward<TTuple>(tuple));
+    } else {
+      return ElementType{std::get<0>(tuple)};
+    }
+  } else {
+    // Note: Always return tuples by value
+    return std::decay_t<TTuple>{std::forward<TTuple>(tuple)};
+  }
+};
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_TUPLE_TRY_FLATTEN_TUPLE_HPP

--- a/include/funkypipes/details/tuple/tuple_indices_of.hpp
+++ b/include/funkypipes/details/tuple/tuple_indices_of.hpp
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_TUPLE_TUPLE_INDICES_OF_HPP
+#define FUNKYPIPES_DETAILS_TUPLE_TUPLE_INDICES_OF_HPP
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/tuple/index_sequence.hpp"
+
+namespace funkypipes::details {
+
+namespace impl {
+
+// Helper template that resolves the requested type to matching indices of the given tuple. The indices are provided as
+// index sequence.
+template <typename TRequested, typename TTuple>
+struct TupleIndicesOfImpl;
+
+template <typename TRequestedElement, typename... TElements>
+struct TupleIndicesOfImpl<TRequestedElement, std::tuple<TElements...>> {
+ private:
+  template <std::size_t... Idxs>
+  static auto findMatchingIndices(std::index_sequence<Idxs...>) {
+    if constexpr (sizeof...(Idxs) == 0) {
+      return std::index_sequence<>{};
+    } else {
+      return indexSequenceCat(std::conditional_t<std::is_same_v<TRequestedElement, std::decay_t<TElements>>,
+                                                 std::index_sequence<Idxs>, std::index_sequence<>>{}...);
+    }
+  }
+
+ public:
+  using type = decltype(findMatchingIndices(std::index_sequence_for<TElements...>{}));
+};
+
+}  // namespace impl
+
+// This template resolves the requested type to matching indices of the given tuple. The indices are provided as index
+// sequence.
+template <typename TRequested, typename TTuple>
+using TupleIndicesOf = typename impl::TupleIndicesOfImpl<TRequested, TTuple>::type;
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_TUPLE_TUPLE_INDICES_OF_HPP

--- a/include/funkypipes/details/tuple/tuple_traits.hpp
+++ b/include/funkypipes/details/tuple/tuple_traits.hpp
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#ifndef FUNKYPIPES_DETAILS_TUPLE_TUPLE_TRAITS_HPP
+#define FUNKYPIPES_DETAILS_TUPLE_TUPLE_TRAITS_HPP
+
+#include <tuple>
+
+namespace funkypipes::details {
+
+namespace impl {
+
+template <typename T>
+struct IsTupleImpl : std::false_type {};
+template <typename... T>
+struct IsTupleImpl<std::tuple<T...>> : std::true_type {};
+
+}  // namespace impl
+
+// A type trait that checks if a given type is std::tuple
+template <typename T>
+constexpr bool IsTuple = ::funkypipes::details::impl::IsTupleImpl<T>::value;
+
+}  // namespace funkypipes::details
+
+#endif  // FUNKYPIPES_DETAILS_TUPLE_TUPLE_TRAITS_HPP

--- a/tests/details/tuple/test_index_sequence.cpp
+++ b/tests/details/tuple/test_index_sequence.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include "funkypipes/details/tuple/index_sequence.hpp"
+
+using funkypipes::details::indexSequenceCat;
+
+static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0>{})), std::index_sequence<0>>);
+static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0>{}, std::index_sequence<>{})),
+                             std::index_sequence<0>>);
+static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0, 1>{}, std::index_sequence<3, 4>{})),
+                             std::index_sequence<0, 1, 3, 4>>);
+static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0, 1>{}, std::index_sequence<0, 1>{})),
+                             std::index_sequence<0, 1, 0, 1>>);

--- a/tests/details/tuple/test_index_sequence.cpp
+++ b/tests/details/tuple/test_index_sequence.cpp
@@ -9,6 +9,7 @@
 #include "funkypipes/details/tuple/index_sequence.hpp"
 
 using funkypipes::details::indexSequenceCat;
+using funkypipes::details::ComplementIndexSequence;
 
 static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0>{})), std::index_sequence<0>>);
 static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0>{}, std::index_sequence<>{})),
@@ -17,3 +18,8 @@ static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0, 1>
                              std::index_sequence<0, 1, 3, 4>>);
 static_assert(std::is_same_v<decltype(indexSequenceCat(std::index_sequence<0, 1>{}, std::index_sequence<0, 1>{})),
                              std::index_sequence<0, 1, 0, 1>>);
+
+static_assert(std::is_same_v<ComplementIndexSequence<4, 1, 3>, std::index_sequence<0, 2>>);
+static_assert(std::is_same_v<ComplementIndexSequence<2>, std::index_sequence<0, 1>>);
+static_assert(std::is_same_v<ComplementIndexSequence<2, 0, 1>, std::index_sequence<>>);
+static_assert(std::is_same_v<ComplementIndexSequence<0>, std::index_sequence<>>);

--- a/tests/details/tuple/test_resolve_rvalue_references.cpp
+++ b/tests/details/tuple/test_resolve_rvalue_references.cpp
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/tuple/resolve_rvalue_references.hpp"
+
+using funkypipes::details::resolveRValueReferences;
+
+// Ensure that lvalue tuples are supported
+TEST(ResolveRValueReferences, lvalueTuple_resolveRValueReferencesCalled_validTupleReturned) {
+  // given
+  auto tuple = std::make_tuple(1);
+
+  // when
+  auto result = resolveRValueReferences(tuple);
+
+  // then
+  ASSERT_EQ(result, std::make_tuple(1));
+}
+
+// Ensure that const lvalue tuples are supported
+TEST(ResolveRValueReferences, constLValueTuple_resolveRValueReferencesCalled_validTupleReturned) {
+  // given
+  const auto tuple = std::make_tuple(2);
+
+  // when
+  auto result = resolveRValueReferences(tuple);
+
+  // then
+  ASSERT_EQ(result, std::make_tuple(2));
+}
+
+// Ensure that rvalue tuples are supported
+TEST(ResolveRValueReferences, rvalueTuple_resolveRValueReferencesCalled_validTupleReturned) {
+  // given
+  auto tuple = std::make_tuple(3);
+
+  // when
+  auto result = resolveRValueReferences(std::move(tuple));
+
+  // then
+  ASSERT_EQ(result, std::make_tuple(3));
+}
+
+// Ensure that rvalue references are resolved
+TEST(ResolveRValueReferences, tupleOfRValueReferences_resolveRValueReferencesCalled_tupleContainsValueElements) {
+  // given
+  auto arg1{4};
+  std::string arg2{"five"};
+  auto tuple = std::forward_as_tuple(std::move(arg1), std::move(arg2));
+
+  // when
+  auto result = resolveRValueReferences(tuple);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int, std::string>>);
+  ASSERT_EQ(result, std::make_tuple(4, std::string{"five"}));
+}
+
+// Ensure that lvalue references are preserved
+TEST(ResolveRValueReferences, tupleOfLValueReference_resolveRValueReferencesCalled_tupleStillContainsLValueReference) {
+  // given
+  int arg{6};
+  auto tuple = std::forward_as_tuple(arg);
+
+  // when
+  auto result = resolveRValueReferences(tuple);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int&>>);
+  ASSERT_EQ(result, std::make_tuple(6));
+}
+
+// Ensure that const lvalue references are preserved
+TEST(ResolveRValueReferences,
+     tupleOfConstLValueReference_resolveRValueReferencesCalled_tupleStillContainsConstLValueReference) {
+  // given
+  int arg{7};
+  auto tuple = std::forward_as_tuple(std::as_const(arg));
+
+  // when
+  auto result = resolveRValueReferences(tuple);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<const int&>>);
+  ASSERT_EQ(result, std::make_tuple(7));
+  arg++;
+  ASSERT_EQ(result, std::make_tuple(8));
+}
+

--- a/tests/details/tuple/test_separate_tuple_elements.cpp
+++ b/tests/details/tuple/test_separate_tuple_elements.cpp
@@ -1,0 +1,180 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/tuple/separate_tuple_elements.hpp"
+
+using funkypipes::details::separateTupleElements;
+
+// Ensure that the first element can be separated
+TEST(SeparateTupleElements, threeElementTuple_separatingElement0_Element0AndElements12Returned) {
+  // given
+  auto original = std::make_tuple(1, "two", '3');
+
+  // when
+  auto [separated, remaining] = separateTupleElements<0>(original);
+
+  // then
+  EXPECT_EQ(std::tuple_size<decltype(separated)>(), 1);
+  EXPECT_EQ(std::get<0>(separated), std::get<0>(original));
+
+  EXPECT_EQ(std::tuple_size<decltype(remaining)>(), 2);
+  EXPECT_EQ(std::get<0>(remaining), std::get<1>(original));
+  EXPECT_EQ(std::get<1>(remaining), std::get<2>(original));
+}
+
+// Ensure that a middle element can be separated
+TEST(SeparateTupleElements, threeElementTuple_separatingElement1_Element1AndElements02Returned) {
+  // given
+  auto original = std::make_tuple(1, "two", '3');
+
+  // when
+  auto [separated, remaining] = separateTupleElements<1>(original);
+
+  // then
+  EXPECT_EQ(std::tuple_size<decltype(separated)>(), 1);
+  EXPECT_EQ(std::get<0>(separated), std::get<1>(original));
+
+  EXPECT_EQ(std::tuple_size<decltype(remaining)>(), 2);
+  EXPECT_EQ(std::get<0>(remaining), std::get<0>(original));
+  EXPECT_EQ(std::get<1>(remaining), std::get<2>(original));
+}
+
+// Ensure that the last element can be separated
+TEST(SeparateTupleElements, threeElementTuple_separatingElement2_Element2AndElements01Returned) {
+  // given
+  auto original = std::make_tuple(1, "two", '3');
+
+  // when
+  auto [separated, remaining] = separateTupleElements<2>(original);
+
+  // then
+  EXPECT_EQ(std::tuple_size<decltype(separated)>(), 1);
+  EXPECT_EQ(std::get<0>(separated), std::get<2>(original));
+
+  EXPECT_EQ(std::tuple_size<decltype(remaining)>(), 2);
+  EXPECT_EQ(std::get<0>(remaining), std::get<0>(original));
+  EXPECT_EQ(std::get<1>(remaining), std::get<1>(original));
+}
+
+// Ensure that all available elements can be separated
+TEST(SeparateTupleElements, oneElementTuple_separatingElement0_Element0AndEmptyTupleReturned) {
+  // given
+  auto original = std::make_tuple(1);
+
+  // when
+  auto [separated, remaining] = separateTupleElements<0>(original);
+
+  // then
+  EXPECT_EQ(std::tuple_size<decltype(separated)>(), 1);
+  EXPECT_EQ(std::get<0>(separated), std::get<0>(original));
+
+  EXPECT_EQ(std::tuple_size<decltype(remaining)>(), 0);
+}
+
+// Ensure that multiple elements can be separated
+TEST(SeparateTupleElements, threeElementTuple_separatingElement01_Element01AndElement2Returned) {
+  // given
+  auto original = std::make_tuple(1, "two", '3');
+
+  // when
+  auto [separated, remaining] = separateTupleElements<0, 1>(original);
+
+  // then
+  EXPECT_EQ(std::tuple_size<decltype(separated)>(), 2);
+  EXPECT_EQ(std::get<0>(separated), std::get<0>(original));
+  EXPECT_EQ(std::get<1>(separated), std::get<1>(original));
+
+  EXPECT_EQ(std::tuple_size<decltype(remaining)>(), 1);
+  EXPECT_EQ(std::get<0>(remaining), std::get<2>(original));
+}
+
+// Ensure that separating zero elements works
+TEST(SeparateTupleElements, threeElementTuple_separatingZeroElements_emptyTupleAndElements012Returned) {
+  // given
+  auto original = std::make_tuple(1, "two", '3');
+
+  // when
+  auto [separated, remaining] = separateTupleElements<>(original);
+
+  // then
+  EXPECT_EQ(std::tuple_size<decltype(separated)>(), 0);
+
+  EXPECT_EQ(std::tuple_size<decltype(remaining)>(), 3);
+  EXPECT_EQ(std::get<0>(remaining), std::get<0>(original));
+  EXPECT_EQ(std::get<1>(remaining), std::get<1>(original));
+  EXPECT_EQ(std::get<2>(remaining), std::get<2>(original));
+}
+
+// Ensure that const tuple is supported
+TEST(SeparateTupleElements, constTuple_separated_works) {
+  // given
+  const std::string element0{"0"};
+  const std::string element1{"1"};
+  const auto original = std::make_tuple(element0, element1);
+
+  // when
+  auto [separated, remaining] = separateTupleElements<0>(original);
+
+  // then
+  EXPECT_EQ(std::get<0>(separated), "0");
+  EXPECT_EQ(std::get<0>(remaining), "1");
+}
+
+// Ensure that rvalue elements are supported
+TEST(SeparateTupleElements, tupleWithRValueElements_separated_elementsAccessableAsRValue) {
+  // given
+  struct NonCopyableStruct {
+    explicit NonCopyableStruct(int value) : value_(value) {}
+    ~NonCopyableStruct() = default;
+    NonCopyableStruct(const NonCopyableStruct&) = delete;
+    NonCopyableStruct(NonCopyableStruct&&) = default;
+    NonCopyableStruct& operator=(const NonCopyableStruct&) = delete;
+    NonCopyableStruct& operator=(NonCopyableStruct&&) = delete;
+
+    int value_;
+  };
+  auto original = std::make_tuple(NonCopyableStruct{0}, NonCopyableStruct{1});
+
+  // when
+  auto [separated, remaining] = separateTupleElements<0>(std::move(original));
+
+  // then
+  EXPECT_EQ(std::get<0>(separated).value_, 0);
+  auto element1 = std::get<0>(std::move(remaining));
+  EXPECT_EQ(element1.value_, 1);
+}
+
+// Ensure that the exact element type is preserved
+TEST(SeparateTupleElements, tupleWithVariousElementTypes_separated_elementsTypesArePreserved) {
+  // given
+  int arg2{2};
+  int arg3{3};
+  const int arg4{4};
+  const int arg5{5};
+  std::tuple<int, int, int&, int&, const int&, const int&, int&&, int&&> original{0, 1, arg2, arg3, arg4, arg5, 6, 7};
+
+  // when
+  auto [separated, remaining] = separateTupleElements<0, 2, 4, 6>(std::move(original));
+
+  // then
+  static_assert(std::is_same_v<decltype(separated), std::tuple<int, int&, const int&, int&&>>);
+  static_assert(std::is_same_v<decltype(remaining), std::tuple<int, int&, const int&, int&&>>);
+}
+
+// TEST(SeparateTupleElements, TwoElementTuple_separatingThirdElement_TriggersStaticAssert) {
+//   auto original = std::make_tuple(1, "two");
+//
+//   auto [separated, remaining] = separateTupleElements<2>(original);
+// }
+

--- a/tests/details/tuple/test_try_flatten_tuple.cpp
+++ b/tests/details/tuple/test_try_flatten_tuple.cpp
@@ -1,0 +1,169 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/tuple/try_flatten_tuple.hpp"
+
+using funkypipes::details::tryFlattenTuple;
+
+// Ensure that multiple elements tuple work
+TEST(TryFlattenTuple, tupleWithMultipleElements_tryFlattened_tupleReturnedUnchanged) {
+  // given
+  auto original = std::make_tuple(1, std::string{"two"});
+
+  // when
+  auto modified = tryFlattenTuple(original);
+
+  // then
+  static_assert(std::is_same_v<decltype(modified), std::tuple<int, std::string>>);
+  EXPECT_EQ(modified, original);
+}
+
+// Ensure that single element tuple work
+TEST(TryFlattenTuple, tupleWithSingleElement_tryFlattened_elementReturned) {
+  // given
+  auto original = std::make_tuple(1);
+
+  // when
+  auto element = tryFlattenTuple(original);
+
+  // then
+  EXPECT_EQ(element, 1);
+}
+
+// Ensure that zero element tuple work
+TEST(TryFlattenTuple, tupleWithZeroElement_tryFlattened_voidReturned) {
+  // given
+  auto original = std::make_tuple();
+
+  // when
+  tryFlattenTuple(original);
+
+  // then
+  using ResultType = std::invoke_result_t<decltype(tryFlattenTuple<decltype(original)>), decltype(original)>;
+  static_assert(std::is_same_v<ResultType, void>);
+}
+
+struct MoveConstructableOnlyStruct {
+  explicit MoveConstructableOnlyStruct(int value) : value_(value) {}
+  ~MoveConstructableOnlyStruct() = default;
+  MoveConstructableOnlyStruct(const MoveConstructableOnlyStruct&) = delete;
+  MoveConstructableOnlyStruct(MoveConstructableOnlyStruct&&) = default;
+  MoveConstructableOnlyStruct& operator=(const MoveConstructableOnlyStruct&) = delete;
+  MoveConstructableOnlyStruct& operator=(MoveConstructableOnlyStruct&&) = delete;
+
+  int value_;  // NOLINT public visibility is intended here
+};
+
+// Ensure that a lvalue reference tuple is returned by value
+TEST(TryFlattenTuple, lvalueTupleWithMultipleElements_tryFlattened_tupleReturnedByValue) {
+  // given
+  auto original = std::make_tuple(0, 1);
+
+  // when
+  decltype(auto) modified = tryFlattenTuple(original);
+
+  // then
+  static_assert(std::is_same_v<decltype(modified), std::tuple<int, int>>);
+  EXPECT_EQ(std::get<0>(modified), 0);
+  EXPECT_EQ(std::get<1>(modified), 1);
+}
+
+// Ensure that a const lvalue reference tuple is returned by value
+TEST(TryFlattenTuple, constLValueTupleWithMultipleElements_tryFlattened_tupleReturnedByValue) {
+  // given
+  auto original = std::make_tuple(0, 1);
+
+  // when
+  decltype(auto) modified = tryFlattenTuple(std::as_const(original));
+
+  // then
+  static_assert(std::is_same_v<decltype(modified), std::tuple<int, int>>);
+  EXPECT_EQ(std::get<0>(modified), 0);
+  EXPECT_EQ(std::get<1>(modified), 1);
+}
+
+// Ensure that a rvalue reference tuple is returned by value
+TEST(TryFlattenTuple, rvalueTupleWithMultipleElements_tryFlattened_tupleReturnedByValue) {
+  // given
+  auto original = std::make_tuple(0, 1);
+
+  // when
+  decltype(auto) modified = tryFlattenTuple(std::move(original));
+
+  // then
+  static_assert(std::is_same_v<decltype(modified), std::tuple<int, int>>);
+  EXPECT_EQ(std::get<0>(modified), 0);
+  EXPECT_EQ(std::get<1>(modified), 1);
+}
+
+// Ensure that a tuple with single value element leads to a value result
+TEST(TryFlattenTuple, lvalueTupleWithSingleElement_tryFlattened_elementReturnedByValue) {
+  // given
+  auto original = std::make_tuple(0);
+
+  // when
+  decltype(auto) outputElement = tryFlattenTuple(original);
+
+  // then
+  static_assert(std::is_same_v<decltype(outputElement), int>);
+  EXPECT_EQ(outputElement, 0);
+}
+
+// Ensure that a tupe with single lvalue reference element leads to a lvalue reference result
+TEST(TryFlattenTuple, lvalueTupleWithSingleElement_tryFlattened_elementReturnedByLValueReference) {
+  // given
+  MoveConstructableOnlyStruct inputElement{0};
+  auto original = std::forward_as_tuple(inputElement);
+
+  // when
+  decltype(auto) outputElement = tryFlattenTuple(original);
+
+  // then
+  static_assert(std::is_same_v<decltype(outputElement), MoveConstructableOnlyStruct&>);
+  EXPECT_EQ(outputElement.value_, 0);
+  outputElement.value_ = 1;
+  EXPECT_EQ(inputElement.value_, 1);
+}
+
+// Ensure that a tupe with single const lvalue reference element leads to a const lvalue reference result
+TEST(TryFlattenTuple, constLValueTupleWithSingleElement_tryFlattened_elementReturnedByConstLValueReference) {
+  // given
+  MoveConstructableOnlyStruct inputElement{0};
+  auto original = std::forward_as_tuple(std::as_const(inputElement));
+
+  // when
+  decltype(auto) outputElement = tryFlattenTuple(original);
+
+  // then
+  static_assert(std::is_same_v<decltype(outputElement), const MoveConstructableOnlyStruct&>);
+  EXPECT_EQ(outputElement.value_, 0);
+  inputElement.value_ = 1;
+  EXPECT_EQ(outputElement.value_, 1);
+}
+
+// Ensure that a tupe with single rvalue reference element leads to a rvalue reference result
+TEST(TryFlattenTuple, rvalueTupleWithSingleElement_tryFlattened_elementReturnedByRValueReference) {
+  // given
+  MoveConstructableOnlyStruct inputElement{
+      0};  // Note: the object to move from needs still to be available when accessing the rvalue reference in the end
+  auto original = std::forward_as_tuple(std::move(inputElement));
+
+  // when
+  decltype(auto) outputElement = tryFlattenTuple(std::move(original));
+
+  // then
+  static_assert(std::is_same_v<decltype(outputElement), MoveConstructableOnlyStruct&&>);
+  EXPECT_EQ(outputElement.value_, 0);
+}
+

--- a/tests/details/tuple/test_tuple_indices_of.cpp
+++ b/tests/details/tuple/test_tuple_indices_of.cpp
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include <tuple>
+
+#include "funkypipes/details/tuple/tuple_indices_of.hpp"
+
+using funkypipes::details::TupleIndicesOf;
+
+static_assert(std::is_same_v<TupleIndicesOf<int, std::tuple<int>>, std::index_sequence<0>>);
+static_assert(std::is_same_v<TupleIndicesOf<int, std::tuple<int&>>, std::index_sequence<0>>);
+static_assert(std::is_same_v<TupleIndicesOf<int, std::tuple<const int&>>, std::index_sequence<0>>);
+static_assert(std::is_same_v<TupleIndicesOf<int, std::tuple<char>>, std::index_sequence<>>);
+static_assert(std::is_same_v<TupleIndicesOf<int, std::tuple<int, char, double, int>>, std::index_sequence<0, 3>>);
+static_assert(std::is_same_v<TupleIndicesOf<int, std::tuple<>>, std::index_sequence<>>);

--- a/tests/details/tuple/test_tuple_traits.cpp
+++ b/tests/details/tuple/test_tuple_traits.cpp
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2024 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include "funkypipes/details/tuple/tuple_traits.hpp"
+
+using funkypipes::details::IsTuple;
+
+static_assert(not IsTuple<int>);
+static_assert(IsTuple<std::tuple<>>);
+static_assert(IsTuple<std::tuple<int>>);
+static_assert(IsTuple<std::tuple<int, double>>);
+

--- a/tests/predefined/execution_semantics/make_pipe_tests.hpp
+++ b/tests/predefined/execution_semantics/make_pipe_tests.hpp
@@ -176,28 +176,34 @@ void compositionWithValueArgument_calledWithRValue_works(TFn makePipeFn) {
 
 template <typename TFn>
 void callablesForwardingConstRefererence_composed_constReferencesArePreserved(TFn makePipeFn) {
+  // given
   auto lambda = [](const int& value) -> const int& { return value; };
-
   auto pipe = makePipeFn(lambda, lambda);
 
+  // when
   int argument{0};
-  const int& result = pipe(argument);
-  ASSERT_EQ(result, 0);
+  decltype(auto) result = pipe(argument);
 
+  // then
+  static_assert(std::is_same_v<decltype(result), const int&>);
+  ASSERT_EQ(result, 0);
   argument++;
   ASSERT_EQ(result, 1);
 }
 
 template <typename TFn>
 void callablesForwardingRefererence_composed_referencesArePreserved(TFn makePipeFn) {
+  // given
   auto lambda = [](int& value) -> int& { return value; };
-
   auto pipe = makePipeFn(lambda, lambda);
 
+  // when
   int argument{1};
-  int& result = pipe(argument);
-  ASSERT_EQ(result, 1);
+  decltype(auto) result = pipe(argument);
 
+  // then
+  static_assert(std::is_same_v<decltype(result), int&>);
+  ASSERT_EQ(result, 1);
   result++;
   ASSERT_EQ(argument, 2);
 }

--- a/tests/test_at.cpp
+++ b/tests/test_at.cpp
@@ -1,0 +1,481 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/at.hpp"
+
+using funkypipes::at;
+
+// Ensure that transforming the only argument works
+TEST(At, argument0AssignedToCallableTransformingItsArgument_calledWithSingleArguments_transformationReturned) {
+  // given
+  auto transformingFn = [](int arg) { return arg + 1; };
+  auto fnAt0 = at<0>(transformingFn);
+
+  // when
+  const auto result = fnAt0(0);
+
+  // then
+  ASSERT_EQ(result, 1);
+}
+
+// Ensure that transforming one argument out of many works
+TEST(
+    At,
+    argument1AssignedToCallableTransformingItsArgument_calledWithTwoArguments_argument0RemainsAndTransformationReturnedAt1) {
+  // given
+  auto transformingFn = [](int arg) { return arg + 1; };
+  auto fnAt1 = at<1>(transformingFn);
+
+  // when
+  const auto result = fnAt1(std::string{"one"}, 2);
+
+  // then
+  ASSERT_EQ(std::get<0>(result), "one");
+  ASSERT_EQ(std::get<1>(result), 3);
+}
+
+// Ensure that transforming multiple arguments out of many works
+TEST(
+    At,
+    arguments01AssignedToCallableTransformingItsArguments_calledWithFourArguments_arguments34ReturnedAt01AndTransformationReturnedAt2) {
+  // given
+  auto transformingFn = [](int arg1, std::string arg2) { return std::to_string(arg1) + arg2; };
+  auto fnAt01 = at<0, 1>(transformingFn);
+
+  // when
+  const auto result = fnAt01(1, std::string{"two"}, 3.0, std::string{"four"});
+
+  // then
+  ASSERT_EQ(std::get<0>(result), 3.0);
+  ASSERT_EQ(std::get<1>(result), "four");
+  ASSERT_EQ(std::get<2>(result), "1two");
+}
+
+// Ensure that const lvalue references are preserved in context of multiple selected arguments
+TEST(At, multipleArgumentsAssignedToCallableForwardingConstLValueReferences_called_constReferencesArePreserved) {
+  // given
+  auto forwardingFn = [](const int& arg1, const std::string& arg2) { return std::forward_as_tuple(arg1, arg2); };
+  auto fnAt01 = at<0, 1>(forwardingFn);
+
+  // when
+  int arg1{1};
+  std::string arg2{"two"};
+  decltype(auto) result = fnAt01(std::as_const(arg1), std::as_const(arg2));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<const int&, const std::string&>>);
+  ASSERT_EQ(std::get<0>(result), 1);
+  ASSERT_EQ(std::get<1>(result), "two");
+  arg1 = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  arg2 = "three";
+  ASSERT_EQ(std::get<0>(result), 2);
+  ASSERT_EQ(std::get<1>(result), "three");
+}
+
+// Ensure that lvalue references are preserved in context of multiple selected arguments
+TEST(At, multipleArgumentsAssignedToCallableForwardingValueReferences_called_referencesArePreserved) {
+  // given
+  auto forwardingFn = [](int& arg1, std::string& arg2) { return std::forward_as_tuple(arg1, arg2); };
+  auto fnAt01 = at<0, 1>(forwardingFn);
+
+  // when
+  int arg1{1};
+  std::string arg2{"two"};
+  decltype(auto) result = fnAt01(arg1, arg2);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int&, std::string&>>);
+  ASSERT_EQ(std::get<0>(result), 1);
+  ASSERT_EQ(std::get<1>(result), "two");
+  std::get<0>(result) = 2;
+  std::get<1>(result) = "three";
+  ASSERT_EQ(arg1, 2);
+  ASSERT_EQ(arg2, "three");
+}
+
+// Ensure that rvalue references are preserved in context of multiple selected arguments
+TEST(At, multipleArgumentsAssignedToCallableForwardingRValueReferences_called_referencesArePreserved) {
+  // given
+  auto forwardingFn = [](int&& arg1, std::string&& arg2) {
+    return std::forward_as_tuple(std::move(arg1), std::move(arg2));
+  };
+  auto fnAt01 = at<0, 1>(forwardingFn);
+
+  // when
+  int arg1{1};              // NOLINT misc-const-correctness: is about to be moved
+  std::string arg2{"two"};  // NOLINT misc-const-correctness: is about to be moved
+  decltype(auto) result = fnAt01(std::move(arg1), std::move(arg2));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int&&, std::string&&>>);
+  ASSERT_EQ(std::get<0>(result), 1);
+  ASSERT_EQ(std::get<1>(result), "two");
+}
+
+// Ensure that const lvalue references are preserved in context of a single selected argument
+TEST(At, singleArgumentAssignedToCallableForwardingConstLValueReferences_called_referencesArePreserved) {
+  // given
+  auto forwardingFn = [](const int& arg) -> const int& { return arg; };
+  auto fnAt0 = at<0>(forwardingFn);
+
+  // when
+  int arg{1};
+  decltype(auto) result = fnAt0(std::as_const(arg));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), const int&>);
+  ASSERT_EQ(result, 1);
+  arg = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  ASSERT_EQ(result, 2);
+}
+
+// Ensure that lvalue references are preserved in context of a single selected argument
+TEST(At, singleArgumentAssignedToCallableForwardingLValueReferences_called_referencesArePreserved) {
+  // given
+  auto forwardingFn = [](int& arg) -> int& { return arg; };
+  auto fnAt0 = at<0>(forwardingFn);
+
+  // when
+  int arg{1};
+  decltype(auto) result = fnAt0(arg);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), int&>);
+  ASSERT_EQ(result, 1);
+  result = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  ASSERT_EQ(arg, 2);
+}
+
+// Ensure that rvalue references are preserved in context of a single selected argument
+TEST(At, singleArgumentAssignedToCallableForwardingRValueReferences_called_referencesArePreserved) {
+  // given
+  auto forwardingFn = [](int&& arg) -> int&& { return std::move(arg); };
+  auto fnAt0 = at<0>(forwardingFn);
+
+  // when
+  int arg{1};  // NOLINT misc-const-correctness: is about to be moved
+  decltype(auto) result = fnAt0(std::move(arg));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), int&&>);
+  ASSERT_EQ(result, 1);
+}
+
+// Ensure that const lvalue references are preserved in context of a single not selected argument
+TEST(At, noArgumentsAssignedToCallable_calledWithConstLValueReference_referenceIsPreserved) {
+  // given
+  auto forwardingFn = []() {};
+  auto fnAt01 = at<>(forwardingFn);
+
+  // when
+  int arg{1};
+  decltype(auto) result = fnAt01(std::as_const(arg));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), const int&>);
+  ASSERT_EQ(result, 1);
+  arg = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  ASSERT_EQ(result, 2);
+}
+
+// Ensure that lvalue references are preserved in context of a single not selected argument
+TEST(At, noArgumentsAssignedToCallable_calledWithLValueReference_referenceIsPreserved) {
+  // given
+  auto forwardingFn = []() {};
+  auto fnAt01 = at<>(forwardingFn);
+
+  // when
+  int arg{1};
+  decltype(auto) result = fnAt01(arg);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), int&>);
+  ASSERT_EQ(result, 1);
+  result = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  ASSERT_EQ(arg, 2);
+}
+
+// Ensure that rvalue references are resolved in context of a single not selected argument
+TEST(At, noArgumentsAssignedToCallable_calledWithRValueReference_returnedByValue) {
+  // given
+  auto forwardingFn = []() {};
+  auto fnAt01 = at<>(forwardingFn);
+
+  // when
+  int arg{1};  // NOLINT misc-const-correctness: is about to be moved
+  decltype(auto) result = fnAt01(std::move(arg));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), int>);
+  ASSERT_EQ(result, 1);
+}
+
+// Ensure that const lvalue references are preserved in context of multiple not selected arguments
+TEST(At, noArgumentsAssignedToCallable_calledWithMultipleConstLValueReferences_referencesArePreserved) {
+  // given
+  auto forwardingFn = []() {};
+  auto fnAt01 = at<>(forwardingFn);
+
+  // when
+  int arg1{1};
+  std::string arg2{"two"};
+  decltype(auto) result = fnAt01(std::as_const(arg1), std::as_const(arg2));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<const int&, const std::string&>>);
+  ASSERT_EQ(std::get<0>(result), 1);
+  ASSERT_EQ(std::get<1>(result), "two");
+  arg1 = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  arg2 = "three";
+  ASSERT_EQ(std::get<0>(result), 2);
+  ASSERT_EQ(std::get<1>(result), "three");
+}
+// Ensure that lvalue references are preserved in context of multiple not selected arguments
+TEST(At, noArgumentsAssignedToCallable_calledWithMultipleLValueReferences_referencesArePreserved) {
+  // given
+  auto forwardingFn = []() {};
+  auto fnAt01 = at<>(forwardingFn);
+
+  // when
+  int arg1{1};
+  std::string arg2{"two"};
+  decltype(auto) result = fnAt01(arg1, arg2);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int&, std::string&>>);
+  ASSERT_EQ(std::get<0>(result), 1);
+  ASSERT_EQ(std::get<1>(result), "two");
+  std::get<0>(result) = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: This actually has an effect
+  std::get<1>(result) = "three";
+  ASSERT_EQ(arg1, 2);
+  ASSERT_EQ(arg2, "three");
+}
+
+// Ensure that rvalue references are resolved in context of multiple not selected arguments
+TEST(At, noArgumentsAssignedToCallable_calledWithMultipleRValueReferences_returnedByValue) {
+  // given
+  auto forwardingFn = []() {};
+  auto fnAt01 = at<>(forwardingFn);
+
+  // when
+
+  decltype(auto) result = fnAt01(int{1}, std::string{"two"});
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int, std::string>>);
+  ASSERT_EQ(std::get<0>(result), 1);
+  ASSERT_EQ(std::get<1>(result), "two");
+}
+
+// Ensure that consuming the only argument works
+TEST(At, argument0AssignedToCallableConsumingItsArgument_calledWithSingleArguments_executedAndVoidReturned) {
+  // given
+  bool fnExecuted{false};
+  auto consumingFn = [&fnExecuted](int) { fnExecuted = true; };
+
+  auto fnAt0 = at<0>(consumingFn);
+
+  // when
+  fnAt0(2);
+
+  // then
+  ASSERT_TRUE(fnExecuted);
+
+  using ResultType = std::invoke_result_t<decltype(fnAt0), int>;
+  static_assert(std::is_same_v<ResultType, void>);
+}
+
+// Ensure that consuming one argument out of many works
+TEST(At, argument1AssignedToCallableConsumingItsArguments_calledWithTwoArguments_executedAndArgument0Remains) {
+  // given
+  bool fnExecuted{false};
+  auto consumingFn = [&fnExecuted](int) { fnExecuted = true; };
+
+  auto fnAt1 = at<1>(consumingFn);
+
+  // when
+  const auto result = fnAt1(std::string{"one"}, 2);
+
+  // then
+  ASSERT_TRUE(fnExecuted);
+  ASSERT_EQ(result, "one");
+}
+
+// Ensure that consuming multiple arguments out of many works
+TEST(At, arguments01AssignedToCallableConsumingItsArgument_calledWithFourArguments_executedAndArguments34Remain) {
+  // given
+  bool fnExecuted{false};
+  auto consumingFn = [&fnExecuted](int, std::string) { fnExecuted = true; };
+
+  auto fnAt01 = at<0, 1>(consumingFn);
+
+  // when
+  auto result = fnAt01(1, std::string{"two"}, 3.0, std::string{"four"});
+
+  // then
+  ASSERT_TRUE(fnExecuted);
+  ASSERT_EQ(std::get<0>(result), 3.0);
+  ASSERT_EQ(std::get<1>(result), "four");
+}
+
+// Ensure that a generic lambda is supported
+TEST(At, genericCallable_calledWithIntegerAndString_works) {
+  // given
+  auto genericFn = [](auto arg) { return arg + arg; };
+  auto fnAt1 = at<1>(genericFn);
+
+  // when
+  const auto result1 = fnAt1(1, 2);
+  const auto result2 = fnAt1(1, std::string{"two"});
+
+  // then
+  ASSERT_EQ(std::get<1>(result1), 4);
+  ASSERT_EQ(std::get<1>(result2), "twotwo");
+}
+
+// Ensure that move only fn is accepted
+TEST(At, NonCopyableFunctorDecorated_called_isExecuted) {
+  // given
+  bool isExecuted{false};
+  struct NonCopyableFn {
+    explicit NonCopyableFn(bool& isExecuted) : isExecuted_{isExecuted} {}
+
+    ~NonCopyableFn() = default;
+    NonCopyableFn(const NonCopyableFn&) = delete;
+    NonCopyableFn(NonCopyableFn&&) = default;
+    NonCopyableFn& operator=(const NonCopyableFn&) = delete;
+    NonCopyableFn& operator=(NonCopyableFn&&) = delete;
+
+    void operator()(int) const { isExecuted_ = true; }
+
+    bool& isExecuted_;  // NOLINT misc-non-private-member-variables-in-classes: intended
+  };
+  auto fnAt0 = at<0>(NonCopyableFn{isExecuted});
+
+  // when
+  fnAt0(1);
+
+  // then
+  ASSERT_TRUE(isExecuted);
+}
+
+// Ensure that a selected argument can be non copyable
+TEST(
+    At,
+    argument1AssignedToCallableForwardingItsNonCopyableArgument_calledWithTwoArgumentsWhereArgument1IsNonCopyable_bothArgumentsReturned) {
+  // given
+  struct NonCopyableArg {
+    ~NonCopyableArg() = default;
+    NonCopyableArg(const NonCopyableArg&) = delete;
+    NonCopyableArg(NonCopyableArg&&) = default;
+    NonCopyableArg& operator=(const NonCopyableArg&) = delete;
+    NonCopyableArg& operator=(NonCopyableArg&&) = delete;
+
+    int value_;  // NOLINT misc-non-private-member-variables-in-classes: intended
+  };
+  auto forwardingFn = [](NonCopyableArg arg) { return arg; };
+  auto fnAt1 = at<1>(forwardingFn);
+
+  // when
+  const auto result = fnAt1(std::string{"one"}, NonCopyableArg{2});
+
+  // then
+  ASSERT_EQ(std::get<0>(result), "one");
+  ASSERT_EQ(std::get<1>(result).value_, 2);
+}
+
+// Ensure that a not selected argument can be non copyable
+TEST(
+    At,
+    argument0AssignedToCallableForwardingItsArgument_calledWithTwoArgumentsWhereArgument1IsNonCopyable_bothArgumentsReturned) {
+  // given
+  struct NonCopyableArg {
+    ~NonCopyableArg() = default;
+    NonCopyableArg(const NonCopyableArg&) = delete;
+    NonCopyableArg(NonCopyableArg&&) = default;
+    NonCopyableArg& operator=(const NonCopyableArg&) = delete;
+    NonCopyableArg& operator=(NonCopyableArg&&) = delete;
+
+    int value_;  // NOLINT misc-non-private-member-variables-in-classes: intended
+  };
+  auto forwardingFn = [](std::string arg) { return arg; };
+  auto fnAt0 = at<0>(forwardingFn);
+
+  // when
+  const auto result = fnAt0(std::string{"one"}, NonCopyableArg{2});
+
+  // then
+  ASSERT_EQ(std::get<0>(result).value_, 2);
+  ASSERT_EQ(std::get<1>(result), "one");
+}
+
+// Ensure that selecting a single unique type works
+TEST(At, argumentsOfTypeIntAssignedToCallableTakingASingleInt_calledWithIntAndString_works) {
+  // given
+  auto transformingFn = [](int arg) { return arg + 1; };
+  auto fnAt0 = at<int>(transformingFn);
+
+  // when
+  const auto result = fnAt0(1, "two");
+
+  // then
+  ASSERT_EQ(result, std::make_tuple("two", 2));
+}
+
+// Ensure that selecting multiple unique types works
+TEST(At, argumentsOfTypeIntAndStringAssignedToCallable_calledWithIntAndString_works) {
+  // given
+  auto transformingFn = [](int arg1, std::string arg2) { return std::to_string(arg1) + arg2; };
+  auto fnAt0 = at<int, std::string>(transformingFn);
+
+  // when
+  const auto result = fnAt0(1, std::string{"2"});
+
+  // then
+  ASSERT_EQ(result, "12");
+}
+
+// Ensure that selecting a non unique type works
+TEST(At, argumentsOfTypeIntAssignedToCallableTakingTwoInts_calledWithTwoIntAndString_works) {
+  // given
+  auto transformingFn = [](int arg1, int arg2) { return arg1 + arg2; };
+  auto fnAt0 = at<int>(transformingFn);
+
+  // when
+  const auto result = fnAt0(1, 2, std::string{"three"});
+
+  // then
+  ASSERT_EQ(result, std::make_tuple("three", 3));
+}
+
+// Ensure that not matching signature triggers static assert
+// TEST(At, argumentsOfTypeIntAssignedToCallableTakingTwoInts_calledWithTwoIntAndString_works2) {
+//  // given
+//  auto transformingFn = [](int arg) { return arg; };
+//  auto fnAt0 = at<std::string>(transformingFn);
+//
+//  // when
+//  const auto result = fnAt0(std::string{"0"});
+//}
+
+//// Ensure that selecting an absent type by type raises proper static_assert
+// TEST(At, argumentsOfTypeIntAssignedToCallableTakingTwoInts_calledWithTwoIntAndString_works2) {
+//   // given
+//   auto transformingFn = [](int arg) { return arg; };
+//   auto fnAt0 = at<std::string, int>(transformingFn);
+//
+//   // when
+//   const auto result = fnAt0(0);
+// }

--- a/tests/test_make_auto_pipe.cpp
+++ b/tests/test_make_auto_pipe.cpp
@@ -76,6 +76,15 @@ TEST(MakeAutoPipe, callablesForwardingConstRefererence_composed_constReferencesA
   ASSERT_NO_FATAL_FAILURE(callablesForwardingConstRefererence_composed_constReferencesArePreserved(makeAutoPipeFn));
 }
 
+TEST(MakeAutoPipe, callablesForwardingMultipleConstRefererences_composed_constReferencesArePreserved) {
+  ASSERT_NO_FATAL_FAILURE(
+      callablesForwardingMultipleConstRefererences_composed_constReferencesArePreserved(makeAutoPipeFn));
+}
+
+TEST(MakeAutoPipe, callablesForwardingMultipleRefererences_composed_referencesArePreserved) {
+  ASSERT_NO_FATAL_FAILURE(callablesForwardingMultipleRefererences_composed_referencesArePreserved(makeAutoPipeFn));
+}
+
 // feature: data - move only
 TEST(MakeAutoPipe, callablesWithNonCopyableArguments_composed_works) {
   ASSERT_NO_FATAL_FAILURE(callablesWithNonCopyableArguments_composed_works(makeAutoPipeFn));

--- a/tests/test_make_pipe.cpp
+++ b/tests/test_make_pipe.cpp
@@ -69,6 +69,15 @@ TEST(MakePipe, callablesForwardingConstRefererence_composed_constReferencesArePr
   ASSERT_NO_FATAL_FAILURE(callablesForwardingConstRefererence_composed_constReferencesArePreserved(makePipeFn));
 }
 
+TEST(MakePipe, callablesForwardingMultipleConstRefererences_composed_constReferencesArePreserved) {
+  ASSERT_NO_FATAL_FAILURE(
+      callablesForwardingMultipleConstRefererences_composed_constReferencesArePreserved(makePipeFn));
+}
+
+TEST(MakePipe, callablesForwardingMultipleRefererences_composed_referencesArePreserved) {
+  ASSERT_NO_FATAL_FAILURE(callablesForwardingMultipleRefererences_composed_referencesArePreserved(makePipeFn));
+}
+
 // feature: data - move only
 TEST(MakePipe, callablesWithNonCopyableArguments_composed_works) {
   ASSERT_NO_FATAL_FAILURE(callablesWithNonCopyableArguments_composed_works(makePipeFn));

--- a/tests/test_make_tuple_packing.cpp
+++ b/tests/test_make_tuple_packing.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 mahush (info@mahush.de)
+// Copyright (c) 2025 mahush (info@mahush.de)
 //
 // Distributed under MIT License
 //
@@ -9,87 +9,152 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #include "funkypipes/details/make_tuple_packing.hpp"
 
-using namespace funkypipes;
-using namespace funkypipes::details;
+using funkypipes::details::makeTuplePacking;
 
-TEST(MakeTuplePacking, callable_accecpting_tuple__called_with_lvalue_tuple__works) {
-  auto lambda = [](std::tuple<int> value) { return std::get<int>(value); };
+// Ensure that a lvalue reference tuple gets forwarded while preserving its reference
+TEST(MakeTuplePacking, callableAcceptingTuple_calledWithLValueTuple_referenceIsPreserved) {
+  // given
+  auto lambda = [](std::tuple<int>& arg) -> std::tuple<int>& { return arg; };
 
   auto packing_lambda = makeTuplePacking(lambda);
 
+  // when
   std::tuple<int> argument{1};
-  int res = packing_lambda(argument);
-  EXPECT_EQ(res, 1);
+  decltype(auto) result = packing_lambda(argument);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int>&>);
+  std::get<0>(result) = 2;
+  EXPECT_EQ(std::get<0>(argument), 2);
 }
 
-TEST(MakeTuplePacking, callable_accecpting_tuple__called_with_rvalue_tuple__works) {
-  auto lambda = [](std::tuple<int> value) { return std::get<int>(value); };
+// Ensure that a const lvalue reference tuple gets forwarded while preserving its reference
+TEST(MakeTuplePacking, callableAcceptingTuple_calledWithConstLValueTuple_referenceIsPreserved) {
+  // given
+  auto lambda = [](const std::tuple<int>& arg) -> const std::tuple<int>& { return arg; };
 
   auto packing_lambda = makeTuplePacking(lambda);
 
+  // when
   std::tuple<int> argument{1};
-  int res = packing_lambda(std::move(argument));
-  EXPECT_EQ(res, 1);
+  decltype(auto) result = packing_lambda(std::as_const(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), const std::tuple<int>&>);
+  EXPECT_EQ(std::get<0>(result), 1);
+  std::get<0>(argument) = 2;
+  EXPECT_EQ(std::get<0>(result), 2);
 }
 
-TEST(MakeTuplePacking, callable_accecpting_tuple_of_int__called_with_lvalue_int__works) {
-  auto lambda = [](std::tuple<int> value) { return std::get<int>(value); };
-
+// Ensure that a rvalue reference tuple gets forwarded while preserving its reference
+TEST(MakeTuplePacking, callableAcceptingTuple_calledWithRValueTuple_referenceIsPreserved) {
+  // given
+  auto lambda = [](std::tuple<int>&& arg) -> std::tuple<int>&& { return std::move(arg); };
   auto packing_lambda = makeTuplePacking(lambda);
 
-  int argument{1};
-  int res = packing_lambda(argument);
-  EXPECT_EQ(res, 1);
+  // when
+  std::tuple<int> argument{1};
+  decltype(auto) result = packing_lambda(std::move(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int>&&>);
+  EXPECT_EQ(std::get<0>(result), 1);
 }
 
-TEST(MakeTuplePacking, callable_accecpting_tuple_of_int__called_with_rvalue_int__works) {
-  auto lambda = [](std::tuple<int> value) { return std::get<int>(value); };
-
+// Ensure that a lvalue reference element gets forwarded as tuple while preserving element references
+TEST(MakeTuplePacking, callableAcceptingTupleOfInt_calledWithLValueInt_referenceIsPreserved) {
+  // given
+  auto lambda = [](std::tuple<int&> arg) -> int& { return std::get<0>(arg); };
   auto packing_lambda = makeTuplePacking(lambda);
 
+  // when
   int argument{1};
-  int res = packing_lambda(std::move(argument));
-  EXPECT_EQ(res, 1);
+  decltype(auto) result = packing_lambda(argument);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), int&>);
+  EXPECT_EQ(result, 1);
+  result = 2;
+  EXPECT_EQ(argument, 2);
 }
 
-TEST(MakeTuplePacking, callable_accecpting_tuple_of_int_and_string__called_with_int_and_string__works) {
+// Ensure that a const lvalue reference element gets forwarded as tuple while preserving element references
+TEST(MakeTuplePacking, callableAcceptingTupleOfInt_calledWithConstLValueInt_referenceIsPreserved) {
+  // given
+  auto lambda = [](std::tuple<const int&> arg) -> const int& { return std::get<0>(arg); };
+  auto packing_lambda = makeTuplePacking(lambda);
+
+  // when
+  int argument{1};
+  decltype(auto) result = packing_lambda(std::as_const(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), const int&>);
+  EXPECT_EQ(result, 1);
+  argument = 2;  // NOLINT clang-analyzer-deadcode.DeadStores: false positive
+  EXPECT_EQ(result, 2);
+}
+
+// Ensure that a rvalue reference element gets forwarded as tuple while preserving element references
+TEST(MakeTuplePacking, callableAcceptingTupleOfInt_calledWithRValueInt_referenceIsPreserved) {
+  //
+  // given
+  //
+  struct NonCopyableOrMovableArg {
+    ~NonCopyableOrMovableArg() = default;
+    NonCopyableOrMovableArg(const NonCopyableOrMovableArg&) = delete;
+    NonCopyableOrMovableArg(NonCopyableOrMovableArg&&) = delete;
+    NonCopyableOrMovableArg& operator=(const NonCopyableOrMovableArg&) = delete;
+    NonCopyableOrMovableArg& operator=(NonCopyableOrMovableArg&&) = delete;
+
+    int value_;  // NOLINT misc-non-private-member-variables-in-classes: intended
+  };
+
+  auto lambda = [](std::tuple<NonCopyableOrMovableArg&&> value) -> NonCopyableOrMovableArg&& {
+    return std::get<0>(std::move(value));
+  };
+  auto packing_lambda = makeTuplePacking(lambda);
+
+  // when
+  NonCopyableOrMovableArg argument{1};  // NOLINT: misc-const-correctness: is about to be moved
+  decltype(auto) result = packing_lambda(std::move(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), NonCopyableOrMovableArg&&>);
+  EXPECT_EQ(result.value_, 1);
+}
+
+// Ensure that returning by value works
+TEST(MakeTuplePacking, callableReturningByValue_called_returnedByValue) {
+  // given
+  auto lambda = [](std::tuple<const int> arg) -> int { return std::get<0>(arg); };
+  auto packing_lambda = makeTuplePacking(lambda);
+
+  // when
+  int argument{1};
+  decltype(auto) result = packing_lambda(std::as_const(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), int>);
+  EXPECT_EQ(result, 1);
+}
+
+// Ensure that packing a tuple out of multiple arguments works
+TEST(MakeTuplePacking, callableAccecptingTupleOfIntAndString_calledWithIntAndString_works) {
+  // given
   auto lambda = [](std::tuple<std::string, int> value) {
     return std::get<std::string>(value) + std::to_string(std::get<int>(value));
   };
-
   auto packing_lambda = makeTuplePacking(lambda);
 
-  std::string res = packing_lambda("1", 2);
-  EXPECT_EQ(res, "12");
+  // when
+  const std::string result = packing_lambda("1", 2);
+
+  // then
+  EXPECT_EQ(result, "12");
 }
-
-TEST(MakeTuplePacking,
-     callable_accepting_const_reference_of_tuple__called_with_const_reference__reference_is_preserved) {
-  auto lambda = [](const std::tuple<int>& value) -> const std::tuple<int>& { return value; };
-
-  auto packing_lambda = makeTuplePacking(lambda);
-
-  std::tuple<int> argument{1};
-  const std::tuple<int>& result = packing_lambda(argument);
-  EXPECT_EQ(std::get<int>(result), 1);
-
-  std::get<int>(argument)++;
-  ASSERT_EQ(std::get<int>(result), 2);
-}
-
-TEST(MakeTuplePacking, callable_accepting_reference_of_tuple__called_with_reference__reference_is_preserved) {
-  auto lambda = [](std::tuple<int>& value) -> std::tuple<int>& { return value; };
-
-  auto packing_lambda = makeTuplePacking(lambda);
-
-  std::tuple<int> argument{1};
-  std::tuple<int>& result = packing_lambda(argument);
-  EXPECT_EQ(std::get<int>(result), 1);
-
-  std::get<int>(result)++;
-  ASSERT_EQ(std::get<int>(argument), 2);
-}
-

--- a/tests/test_make_tuple_returning.cpp
+++ b/tests/test_make_tuple_returning.cpp
@@ -1,0 +1,189 @@
+//
+// Copyright (c) 2025 mahush (info@mahush.de)
+//
+// Distributed under MIT License
+//
+// Official repository: https://github/mahush/funkypipes
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "funkypipes/details/make_tuple_returning.hpp"
+
+using funkypipes::details::makeTupleReturning;
+
+// feature: data - void return type
+// Ensure that void returning callables are supported
+TEST(MakeTupleReturning, callableReturningVoid_called_returnsEmptyTuple) {
+  // given
+  auto lambda = [](int) {};
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  decltype(auto) result = tupleReturningFn(0);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<>>);
+}
+
+// Ensure that value returning callables are supported
+TEST(MakeTupleReturning, callableReturningValue_called_returnsTuple) {
+  // given
+  auto lambda = []() { return 1; };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  decltype(auto) result = tupleReturningFn();
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int>>);
+  EXPECT_EQ(std::get<0>(result), 1);
+}
+
+// feature: data - value categories
+// Ensure that lvalue reference returning callables are supported
+TEST(MakeTupleReturning, callableReturningLValueReference_called_referenceIsPreserved) {
+  // given
+  auto lambda = [](int& arg) -> int& { return arg; };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  int argument{1};
+  decltype(auto) result = tupleReturningFn(argument);
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int&>>);
+  EXPECT_EQ(std::get<0>(result), 1);
+  std::get<0>(result) = 2;
+  EXPECT_EQ(argument, 2);
+}
+
+// feature: data - value categories
+// Ensure that const lvalue reference returning callables are supported
+TEST(MakeTupleReturning, callableReturningConstLValueReference_called_referenceIsPreserved) {
+  // given
+  auto lambda = [](const int& arg) -> const int& { return arg; };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  int argument{1};
+  decltype(auto) result = tupleReturningFn(std::as_const(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<const int&>>);
+  EXPECT_EQ(std::get<0>(result), 1);
+  argument = 2;
+  EXPECT_EQ(std::get<0>(result), 2);
+}
+
+// feature: data - value categories
+// Ensure that rvalue reference returning callables are supported
+TEST(MakeTupleReturning, callableReturningRValueReference_called_referenceIsPreserved) {
+  // given
+  auto lambda = [](int&& arg) -> int&& { return std::move(arg); };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  int argument{1};  // Note: object to move from must still exist when accessing result
+  decltype(auto) result = tupleReturningFn(std::move(argument));
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int&&>>);
+  EXPECT_EQ(std::get<0>(result), 1);
+  std::get<0>(result) = 2;
+  EXPECT_EQ(argument,
+            2);  // NOLINT bugprone-use-after-move,hicpp-invalid-access-moved: actually no move has happend here
+}
+
+// Ensure that tuple returning callables are supported
+TEST(MakeTupleReturning, callableReturningTuple_called_returnsTuple) {
+  // given
+  auto lambda = []() { return std::make_tuple(1, std::string{"two"}); };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  decltype(auto) result = tupleReturningFn();
+
+  // then
+  static_assert(std::is_same_v<decltype(result), std::tuple<int, std::string>>);
+  EXPECT_EQ(std::get<0>(result), 1);
+  EXPECT_EQ(std::get<1>(result), std::string{"two"});
+}
+
+// feature callables: move only
+// Ensure that a move-only callable can be wrapped
+TEST(MakeTupleReturning, nonCopyableCallable_called_works) {
+  // given
+  struct NonCopyableFn {
+    ~NonCopyableFn() = default;
+    NonCopyableFn(const NonCopyableFn&) = delete;
+    NonCopyableFn(NonCopyableFn&&) = default;
+    NonCopyableFn& operator=(const NonCopyableFn&) = delete;
+    NonCopyableFn& operator=(NonCopyableFn&&) = delete;
+
+    int operator()(int value) const { return value; }
+  };
+  auto tupleReturningFn = makeTupleReturning(NonCopyableFn{});
+
+  // when
+  std::tuple<int> result = tupleReturningFn(1);
+
+  // then
+  EXPECT_EQ(std::get<0>(result), 1);
+}
+
+// feature data: move only
+// Ensure that a non copyable argument can get passed through
+TEST(MakeTupleReturning, callable_calledWithNonCopyableValue_NonCopyValueReturned) {
+  // given
+  struct NonCopyableArg {
+    ~NonCopyableArg() = default;
+    NonCopyableArg(const NonCopyableArg&) = delete;
+    NonCopyableArg(NonCopyableArg&&) = default;
+    NonCopyableArg& operator=(const NonCopyableArg&) = delete;
+    NonCopyableArg& operator=(NonCopyableArg&&) = delete;
+
+    int value_;  // NOLINT misc-non-private-member-variables-in-classes: inteded
+  };
+  auto lambda = [](NonCopyableArg arg) { return arg; };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  NonCopyableArg argument{1};
+  std::tuple<NonCopyableArg> result = tupleReturningFn(std::move(argument));
+
+  // then
+  ASSERT_EQ(std::get<0>(result).value_, 1);
+}
+
+// feature data: any number of arguments
+// Ensure that zero arguments are supported
+TEST(MakeTupleReturning, callableReturningValue_calledWithoutArguments_works) {
+  // given
+  auto lambda = []() { return "result"; };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  std::tuple<std::string> result = tupleReturningFn();
+
+  // then
+  EXPECT_EQ(std::get<0>(result), "result");
+}
+
+// feature data: any number of arguments
+// Ensure that multiple arguments are supported
+TEST(MakeTupleReturning, callableReturningValue_calledWithMultipleArguments_works) {
+  // given
+  auto lambda = [](int arg1, int arg2) -> int { return arg1 + arg2; };
+  auto tupleReturningFn = makeTupleReturning(lambda);
+
+  // when
+  std::tuple<int> result = tupleReturningFn(1, 2);
+
+  // then
+  EXPECT_EQ(std::get<0>(result), 3);
+}


### PR DESCRIPTION
This PR introduces the function decorator `at` meant to be used within pipelines to transform only the selected types/indices.